### PR TITLE
feat(placement-schemas): add new schemas, for placement context

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,15 @@ project.validate()
 ### Users
 
 * [`UserSchema`](./src/UserSchema.js)
+
+### OrganizationMembership
+
+* [`OrganizationMembershipSchema`](./src/OrganizationMembershipSchema.js)
+
+### JobOpportunity
+
+* [`JobOpportunity`](./src/JobOpportunitySchema.js)
+
+### HiringProcess
+
+* [`HiringProcessSchema`](./src/HiringProcessSchema.js)

--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ const OrganizationSchema = require('./src/OrganizationSchema');
 const ProjectFeedbackSchema = require('./src/ProjectFeedbackSchema');
 const ProjectSchema = require('./src/ProjectSchema');
 const ReviewerSurveySchema = require('./src/ReviewerSurveySchema');
+const HiringProcessSchema = require('./src/HiringProcessSchema');
+const JobOpportunitySchema = require('./src/JobOpportunitySchema');
+const OrganizationMembershipSchema = require('./src/OrganizationMembershipSchema');
 const TopicSchema = require('./src/TopicSchema');
 const TopicUnitSchema = require('./src/TopicUnitSchema');
 const TopicUnitPartSchema = require('./src/TopicUnitPartSchema');
@@ -35,6 +38,9 @@ module.exports = conn => ({
   ProjectFeedbackSchema: ProjectFeedbackSchema(conn),
   ProjectSchema: ProjectSchema(conn),
   ReviewerSurveySchema: ReviewerSurveySchema(conn),
+  HiringProcessSchema: HiringProcessSchema(conn),
+  JobOpportunitySchema: JobOpportunitySchema(conn),
+  OrganizationMembershipSchema: OrganizationMembershipSchema(conn),
   TopicSchema: TopicSchema(conn),
   TopicUnitSchema: TopicUnitSchema(conn),
   TopicUnitPartSchema: TopicUnitPartSchema(conn),

--- a/src/HiringProcessSchema.js
+++ b/src/HiringProcessSchema.js
@@ -1,0 +1,50 @@
+module.exports = (conn) => {
+  const HiringProcessSchema = new conn.Schema({
+    opportunity: {
+      type: conn.Schema.Types.ObjectId,
+      ref: 'JobOpportunity',
+      required: true,
+    },
+    user: {
+      type: conn.Schema.Types.ObjectId,
+      ref: ' User',
+      required: true,
+    },
+    organization: {
+      type: conn.Schema.Types.ObjectId,
+      ref: 'Organization',
+      required: true,
+    },
+    createDate: {
+      type: Date,
+      required: true,
+    },
+    acceptedDate: {
+      type: Date,
+    },
+    createProposalDate: {
+      type: Date,
+    },
+    startDate: {
+      type: Date,
+    },
+    salary: {
+      type: Number,
+    },
+    active: {
+      type: Boolean,
+      required: true,
+    },
+  }, { collection: 'hiring_processes' });
+
+  HiringProcessSchema.index(
+    {
+      opportunity: 1,
+      user: 1,
+    }, {
+      unique: true,
+    },
+  );
+
+  return HiringProcessSchema;
+};

--- a/src/JobOpportunitySchema.js
+++ b/src/JobOpportunitySchema.js
@@ -1,0 +1,59 @@
+module.exports = (conn) => {
+  const JobOpportunitySchema = new conn.Schema({
+    employer: {
+      type: conn.Schema.Types.ObjectId,
+      ref: 'OrganizationMembership',
+      required: true,
+    },
+    address: {
+      type: String,
+      required: true,
+    },
+    city: {
+      type: String,
+      required: true,
+    },
+    campus: {
+      type: conn.Schema.Types.ObjectId,
+      ref: 'Campus',
+      required: true,
+    },
+    vacancies: {
+      type: Number,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+      required: true,
+    },
+    type: {
+      type: String,
+      enum: ['Front-end Developer', 'Prototyper', 'UX Designer'],
+    },
+    hireType: {
+      type: String,
+      enum: ['payroll', 'independent'],
+    },
+    scheduleType: {
+      type: String,
+      enum: ['full-time', 'part-time'],
+    },
+    salaryRange: {
+      type: String,
+      required: true,
+    },
+    tentativeStart: {
+      type: Date,
+      require: true,
+    },
+    active: {
+      type: Boolean,
+      required: true,
+    },
+  }, { collection: 'job_opportunities' });
+  return JobOpportunitySchema;
+};

--- a/src/OrganizationMembershipSchema.js
+++ b/src/OrganizationMembershipSchema.js
@@ -1,0 +1,26 @@
+module.exports = (conn) => {
+  const OrganizationMembershipSchema = new conn.Schema({
+    user: {
+      type: conn.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+      unique: true,
+    },
+    organization: {
+      type: conn.Schema.Types.ObjectId,
+      ref: 'Organization',
+      required: true,
+    },
+    phone: {
+      type: String,
+      required: true,
+    },
+    position: {
+      type: String,
+      required: true,
+    },
+
+  });
+  return OrganizationMembershipSchema;
+};

--- a/src/OrganizationSchema.js
+++ b/src/OrganizationSchema.js
@@ -29,6 +29,10 @@ module.exports = (conn) => {
       type: String,
       trim: true,
     },
+    address: {
+      type: String,
+      trim: true,
+    },
   });
 
   return OrganizationSchema;

--- a/src/__tests__/HiringProcessSchema.spec.js
+++ b/src/__tests__/HiringProcessSchema.spec.js
@@ -1,0 +1,37 @@
+const mongoose = require('mongoose/browser');
+const {
+  JobOpportunitySchema,
+  UserSchema,
+  OrganizationSchema,
+  HiringProcessSchema,
+} = require('../../')(mongoose);
+
+describe('HiringProcessSchema', () => {
+  it('should fail validation when fields missing', () => {
+    const doc = new mongoose.Document({}, HiringProcessSchema);
+    expect(doc.validateSync().errors).toMatchSnapshot();
+  });
+
+  it('should validate ...', (done) => {
+    const opportunity = new mongoose.Document({}, JobOpportunitySchema);
+    const user = new mongoose.Document({}, UserSchema);
+    const organization = new mongoose.Document({}, OrganizationSchema);
+
+    const hiring = new mongoose.Document({
+      opportunity: opportunity._id,
+      user: user._id,
+      organization: organization._id,
+      createDate: new Date(),
+      acceptedDate: new Date(),
+      createProposalDate: new Date(),
+      startDate: new Date(),
+      salary: 1000,
+      active: true,
+    }, HiringProcessSchema);
+
+    hiring.validate((err) => {
+      expect(err).toBe(null);
+      done();
+    });
+  });
+});

--- a/src/__tests__/JobOpportunitySchema.spec.js
+++ b/src/__tests__/JobOpportunitySchema.spec.js
@@ -1,0 +1,35 @@
+const mongoose = require('mongoose/browser');
+const { OrganizationMembershipSchema, JobOpportunitySchema, CampusSchema } = require('../..')(mongoose);
+
+describe('Opportunity', () => {
+  it('should fail validation when fields missing', () => {
+    const doc = new mongoose.Document({}, JobOpportunitySchema);
+    expect(doc.validateSync().errors).toMatchSnapshot();
+  });
+
+  it('should validate ...', (done) => {
+    const employer = new mongoose.Document({}, OrganizationMembershipSchema);
+    const campus = new mongoose.Document({}, CampusSchema);
+
+    const opportunity = new mongoose.Document({
+      employer: employer._id,
+      address: ' Av. Almirante Grau',
+      city: 'Lima',
+      campus: campus._id,
+      vacancies: 3,
+      title: 'Desenvolvedor Front-end Junior',
+      description: 'Mussum Ipsum, cacilds vidis litro abertis. Per aumento de cachacis',
+      type: 'Front-end Developer',
+      hireType: 'payroll',
+      scheduleType: 'part-time',
+      salaryRange: 'R$3.501 to R$4.000',
+      tentativeStart: new Date(),
+      active: true,
+    }, JobOpportunitySchema);
+
+    opportunity.validate((err) => {
+      expect(err).toBe(null);
+      done();
+    });
+  });
+});

--- a/src/__tests__/OrganizationMembershipSchema.spec.js
+++ b/src/__tests__/OrganizationMembershipSchema.spec.js
@@ -1,0 +1,26 @@
+const mongoose = require('mongoose/browser');
+const { OrganizationMembershipSchema, OrganizationSchema, UserSchema } = require('../..')(mongoose);
+
+describe('OrganizationMembershipSchema', () => {
+  it('should fail validation when fields missing', () => {
+    const doc = new mongoose.Document({}, OrganizationMembershipSchema);
+    expect(doc.validateSync().errors).toMatchSnapshot();
+  });
+
+  it('should validate ...', (done) => {
+    const organization = new mongoose.Document({}, OrganizationSchema);
+    const user = new mongoose.Document({}, UserSchema);
+
+    const employer = new mongoose.Document({
+      user: user._id,
+      organization: organization._id,
+      phone: '+5511999999999',
+      position: 'HR',
+    }, OrganizationMembershipSchema);
+
+    employer.validate((err) => {
+      expect(err).toBe(null);
+      done();
+    });
+  });
+});

--- a/src/__tests__/__snapshots__/HiringProcessSchema.spec.js.snap
+++ b/src/__tests__/__snapshots__/HiringProcessSchema.spec.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HiringProcessSchema should fail validation when fields missing 1`] = `
+Object {
+  "active": [ValidatorError: Path \`active\` is required.],
+  "createDate": [ValidatorError: Path \`createDate\` is required.],
+  "opportunity": [ValidatorError: Path \`opportunity\` is required.],
+  "organization": [ValidatorError: Path \`organization\` is required.],
+  "user": [ValidatorError: Path \`user\` is required.],
+}
+`;

--- a/src/__tests__/__snapshots__/JobOpportunitySchema.spec.js.snap
+++ b/src/__tests__/__snapshots__/JobOpportunitySchema.spec.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Opportunity should fail validation when fields missing 1`] = `
+Object {
+  "active": [ValidatorError: Path \`active\` is required.],
+  "address": [ValidatorError: Path \`address\` is required.],
+  "campus": [ValidatorError: Path \`campus\` is required.],
+  "city": [ValidatorError: Path \`city\` is required.],
+  "description": [ValidatorError: Path \`description\` is required.],
+  "employer": [ValidatorError: Path \`employer\` is required.],
+  "salaryRange": [ValidatorError: Path \`salaryRange\` is required.],
+  "title": [ValidatorError: Path \`title\` is required.],
+  "vacancies": [ValidatorError: Path \`vacancies\` is required.],
+}
+`;

--- a/src/__tests__/__snapshots__/OrganizationMembershipSchema.spec.js.snap
+++ b/src/__tests__/__snapshots__/OrganizationMembershipSchema.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OrganizationMembershipSchema should fail validation when fields missing 1`] = `
+Object {
+  "organization": [ValidatorError: Path \`organization\` is required.],
+  "phone": [ValidatorError: Path \`phone\` is required.],
+  "position": [ValidatorError: Path \`position\` is required.],
+  "user": [ValidatorError: Path \`user\` is required.],
+}
+`;


### PR DESCRIPTION
## Context
Placement team started to migrate all placement data to MongoDB, this PR is about how the data is organized.

## Proposal
We added three new schemas, EmployerSchema, OpportunitySchema, HiringProcessSchema and modified one OrganizationSchema.

### OpportunityMembershipSchema
It is the contact from HR (or any other relevant department) of the companies that want to hire our graduates. One Employer is also a User with name, email, etc... in Laboratoria and belongs to one Organization.

### OpportunitySchema
One Employer can create a job opportunity, after publishing an opportunity on https://app.talento.laboratoria.la

### HiringProcessSchema
A HiringProcess refers to the process a Graduate goes through while participating in the different evaluations inside one Opportunity.