### PR TITLE
feat(topics): Adds order property to units and parts

### DIFF
--- a/src/TopicUnitPartSchema.js
+++ b/src/TopicUnitPartSchema.js
@@ -40,12 +40,12 @@ module.exports = (conn, document) => {
         this.searchableBody = domWrapper.textContent;
         return body;
       },
-      // required: true,
     },
     searchableBody: {
       type: String,
     },
     durationString: { type: String, required: true },
+    order: { type: Number },
   }, { collection: 'topic_unit_parts' });
 
   TopicUnitPartSchema.pre('validate', function (next) {

--- a/src/TopicUnitSchema.js
+++ b/src/TopicUnitSchema.js
@@ -18,6 +18,7 @@ module.exports = (conn) => {
       exerciseCount: { type: Number, required: true },
       partCount: { type: Number, required: true },
     },
+    order: { type: Number },
   }, { collection: 'topic_units' });
 
   TopicUnitSchema.index({ topic: 1, slug: 1 }, { unique: true });


### PR DESCRIPTION
This PR introduces an optional `order` property to both _units_ (`TopicUnit`) and _parts_ (`TopicUnitPart`). This change is needes as we now manage units ans parts as separate collections and we need an explicit ordering criteria. The `curriculum-parser` already provides this value, so it's only a matter of adding it to the schemas so it starts storing them from now on. This props are being added as "optional" as older _courses/topics_ may not have these values.

See https://github.com/Laboratoria/curriculum-parser/commit/bace90e3dd9eb73a21e6a6e742cc34cc8623436b