### PR TITLE
Add a common schema to save progress data

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,9 @@ const TopicUnitSchema = require('./src/TopicUnitSchema');
 const TopicUnitPartSchema = require('./src/TopicUnitPartSchema');
 const UserSchema = require('./src/UserSchema');
 const UserActivityFeedEventSchemas = require('./src/UserActivityFeedEventSchemas');
+const ProgressSchema = require('./src/ProgressSchema');
+const ProgressUnitSchema = require('./src/ProgressUnitSchema');
+const ProgressPartSchema = require('./src/ProgressPartSchema');
 
 
 module.exports = (conn, document) => ({
@@ -54,4 +57,7 @@ module.exports = (conn, document) => ({
   TopicUnitPartSchema: TopicUnitPartSchema(conn, document || (typeof window !== 'undefined' ? window : {}).document),
   UserSchema: UserSchema(conn),
   UserActivityFeedEventSchemas: UserActivityFeedEventSchemas(conn),
+  ProgressSchema: ProgressSchema(conn),
+  ProgressUnitSchema: ProgressUnitSchema(conn),
+  ProgressPartSchema: ProgressPartSchema(conn),
 });

--- a/src/ProgressPartSchema.js
+++ b/src/ProgressPartSchema.js
@@ -1,0 +1,18 @@
+module.exports = (conn) => {
+  const ProgressPartSchema = new conn.Schema({
+    part: {
+      type: conn.Schema.Types.ObjectId,
+      ref: 'TopicUnitPart',
+      required: true,
+    },
+    openedAt: { type: Date, default: Date.now },
+    completedAt: { type: Date, default: null }, // it replaces "readAt"
+
+    // should we take into account "latestActivity"?
+    // I think it's used to mark the latest part tackled by user.
+    // TODO: Ask Lupo about it
+    latestActivity: { type: Boolean, default: true },
+  }, { collection: 'progress_parts' });
+
+  return ProgressPartSchema;
+};

--- a/src/ProgressSchema.js
+++ b/src/ProgressSchema.js
@@ -1,0 +1,27 @@
+const ProgressUnitSchema = require('./ProgressUnitSchema');
+
+module.exports = (conn) => {
+  const ProgressSchema = new conn.Schema({
+    cohortTopic: {
+      type: conn.Schema.Types.ObjectId,
+      ref: 'CohortTopic',
+      required: true,
+    },
+    user: {
+      type: conn.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    completedDuration: { type: Number, default: 0 }, // comes from Firestore
+    completedUnits: { type: Number, default: 0 }, // comes from Firestore
+
+    // To show percentage of course that was completed
+    percent: { type: Number, default: 0 }, // comes from Firestore
+
+    // to show when a topic was completed
+    completedAt: { type: Date, default: null },
+    units: [ProgressUnitSchema(conn)],
+  }, { timestamps: true });
+
+  return ProgressSchema;
+};

--- a/src/ProgressUnitSchema.js
+++ b/src/ProgressUnitSchema.js
@@ -1,0 +1,25 @@
+const ProgressPartSchema = require('./ProgressPartSchema');
+
+module.exports = (conn) => {
+  const ProgressUnitSchema = new conn.Schema({
+    unit: {
+      type: conn.Schema.Types.ObjectId,
+      ref: 'TopicUnit',
+      required: true,
+    },
+    completedDuration: { type: Number, default: 0 },
+    completedParts: { type: Number, default: 0 },
+
+    // it indicates percentage of the unit that was completed
+    percent: { type: Number, default: 0 },
+    completedAt: { type: Date, default: null },
+
+    // TODO: ask Lupo or Fabian about this key
+    // selfAssessment structure on Firestore
+    // { completed: 0, sentiment: 1, completedAt: xxx }
+    selfAssessment: Map,
+    parts: [ProgressPartSchema(conn)],
+  }, { collection: 'progress_units' });
+
+  return ProgressUnitSchema;
+};

--- a/src/TopicUnitPartSchema.js
+++ b/src/TopicUnitPartSchema.js
@@ -60,3 +60,5 @@ module.exports = (conn, document) => {
 
   return TopicUnitPartSchema;
 };
+
+// TODO: Exercises and quizzes data

--- a/src/__tests__/ProgressPartSchema.spec.js
+++ b/src/__tests__/ProgressPartSchema.spec.js
@@ -1,0 +1,33 @@
+const mongoose = require('mongoose/browser');
+const {
+  ProgressPartSchema, TopicUnitPartSchema,
+} = require('../..')(mongoose);
+
+describe('ProgressPartSchema', () => {
+  it('should fail validation when fields missing', () => {
+    const doc = new mongoose.Document({}, ProgressPartSchema);
+    return doc.validate()
+      .catch(err => expect(err.errors).toMatchSnapshot());
+  });
+
+  it('should pass at least with unit field', () => {
+    const topicUnitPart = new mongoose.Document({}, TopicUnitPartSchema);
+    const doc = new mongoose.Document({
+      part: topicUnitPart._id,
+    }, ProgressPartSchema);
+
+    return doc.validate();
+  });
+
+  it('should pass with all fields', () => {
+    const topicUnitPart = new mongoose.Document({}, TopicUnitPartSchema);
+    const doc = new mongoose.Document({
+      part: topicUnitPart._id,
+      openedAt: Date.now(),
+      completedAt: Date.now(),
+      latestActivity: true,
+    }, ProgressPartSchema);
+
+    return doc.validate();
+  });
+});

--- a/src/__tests__/ProgressSchema.spec.js
+++ b/src/__tests__/ProgressSchema.spec.js
@@ -1,0 +1,38 @@
+const mongoose = require('mongoose/browser');
+const {
+  ProgressSchema, UserSchema, CohortTopicSchema,
+} = require('../..')(mongoose);
+
+describe('ProgressSchema', () => {
+  it('should fail validation when fields missing', () => {
+    const doc = new mongoose.Document({}, ProgressSchema);
+    return doc.validate()
+      .catch(err => expect(err.errors).toMatchSnapshot());
+  });
+
+  it('should pass at least with user and cohortTopic fields', () => {
+    const user = new mongoose.Document({}, UserSchema);
+    const cohortTopic = new mongoose.Document({}, CohortTopicSchema);
+    const doc = new mongoose.Document({
+      user: user._id,
+      cohortTopic: cohortTopic._id,
+    }, ProgressSchema);
+
+    return doc.validate();
+  });
+
+  it('should pass with all fields', () => {
+    const user = new mongoose.Document({}, UserSchema);
+    const cohortTopic = new mongoose.Document({}, CohortTopicSchema);
+    const doc = new mongoose.Document({
+      user: user._id,
+      cohortTopic: cohortTopic._id,
+      completedDuration: 20,
+      completedUnits: 5,
+      percent: 20,
+      completedAt: Date.now(),
+    }, ProgressSchema);
+
+    return doc.validate();
+  });
+});

--- a/src/__tests__/ProgressUnitSchema.spec.js
+++ b/src/__tests__/ProgressUnitSchema.spec.js
@@ -1,0 +1,34 @@
+const mongoose = require('mongoose/browser');
+const {
+  ProgressUnitSchema, TopicUnitSchema,
+} = require('../..')(mongoose);
+
+describe('ProgressUnitSchema', () => {
+  it('should fail validation when fields missing', () => {
+    const doc = new mongoose.Document({}, ProgressUnitSchema);
+    return doc.validate()
+      .catch(err => expect(err.errors).toMatchSnapshot());
+  });
+
+  it('should pass at least with unit field', () => {
+    const topicUnit = new mongoose.Document({}, TopicUnitSchema);
+    const doc = new mongoose.Document({
+      unit: topicUnit._id,
+    }, ProgressUnitSchema);
+
+    return doc.validate();
+  });
+
+  it('should pass with all fields', () => {
+    const topicUnit = new mongoose.Document({}, TopicUnitSchema);
+    const doc = new mongoose.Document({
+      unit: topicUnit._id,
+      completedDuration: 20,
+      completedParts: 5,
+      percent: 100,
+      completedAt: Date.now(),
+    }, ProgressUnitSchema);
+
+    return doc.validate();
+  });
+});

--- a/src/__tests__/__snapshots__/ProgressPartSchema.spec.js.snap
+++ b/src/__tests__/__snapshots__/ProgressPartSchema.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProgressPartSchema should fail validation when fields missing 1`] = `
+Object {
+  "part": [ValidatorError: Path \`part\` is required.],
+}
+`;

--- a/src/__tests__/__snapshots__/ProgressSchema.spec.js.snap
+++ b/src/__tests__/__snapshots__/ProgressSchema.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProgressSchema should fail validation when fields missing 1`] = `
+Object {
+  "cohortTopic": [ValidatorError: Path \`cohortTopic\` is required.],
+  "user": [ValidatorError: Path \`user\` is required.],
+}
+`;

--- a/src/__tests__/__snapshots__/ProgressUnitSchema.spec.js.snap
+++ b/src/__tests__/__snapshots__/ProgressUnitSchema.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProgressUnitSchema should fail validation when fields missing 1`] = `
+Object {
+  "unit": [ValidatorError: Path \`unit\` is required.],
+}
+`;


### PR DESCRIPTION
Part of https://github.com/Laboratoria/api.laboratoria.la/issues/139

### What?
The three mongoose schemas gather keys of the current collections related to progress that we are keeping on Firestore for both Admission (/dashboard) and LMS (Look at the link above:point_up:).

### Approach
The **intention** of this PR is not to design a new progress model by envisioning what could be the right progress model, but creating a model based on what we already have on hand, since we have to guarantee backward-compatibility with the current model on Firestore.

### Why Embedding?
I favored embedding over referring because we have the main use case where progress data is fetched all-in-one.

**Use case**  to show stats and completeness about units and parts on one view.

![dsdsdsdsds](https://user-images.githubusercontent.com/9435850/65256901-ea8c8180-dac5-11e9-92c6-819dfee728b9.png)